### PR TITLE
preserve security capabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       image: mcr.microsoft.com/cbl-mariner/base/core:2.0
     steps:
       - name: Install dependencies
-        run: unset HOME; tdnf install -y build-essential git openssl-devel python3-devel sudo ca-certificates dnf
+        run: unset HOME; tdnf install -y build-essential git openssl-devel python3-devel sudo ca-certificates dnf moby-cli skopeo
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -36,7 +36,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Run cargo test
-        run: cargo test
+        run: cargo test --features test-docker
 
   cargo-deny:
     runs-on: ubuntu-22.04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,6 +648,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +828,7 @@ dependencies = [
  "log",
  "oci-spec",
  "openssl",
+ "pathdiff",
  "pyo3",
  "serde",
  "serde_json",
@@ -831,6 +838,7 @@ dependencies = [
  "toml",
  "url",
  "walkdir",
+ "xattr 1.0.1",
 ]
 
 [[package]]
@@ -949,7 +957,7 @@ checksum = "ec96d2ffad078296368d46ff1cb309be1c23c513b4ab0e22a45de0185275ac96"
 dependencies = [
  "filetime",
  "libc",
- "xattr",
+ "xattr 0.2.3",
 ]
 
 [[package]]
@@ -1290,6 +1298,15 @@ name = "xattr"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "xattr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ glob = "0.3.0"
 log = "0.4.19"
 oci-spec = { version = "0.6.1", features = ["image"], default-features = false }
 openssl = "0.10.55"
+pathdiff = "0.2.1"
 pyo3 = { version = "0.19.1", features = ["auto-initialize"] }
 serde = { version = "1.0.139", features = ["derive"] }
 serde_json = "1.0.102"
@@ -27,6 +28,7 @@ termcolor = "1.1.3"
 toml = { version = "0.7.1" }
 url = { version = "2.2.2", features = ["serde"] }
 walkdir = "2.3.2"
+xattr = "1.0.1"
 
 [package.metadata.generate-rpm]
 assets = [
@@ -37,3 +39,7 @@ require-sh = false
 
 [package.metadata.generate-rpm.requires]
 dnf = "*"
+
+[features]
+# The "test-docker" feature is used to run integration tests requiring skopeo and docker
+test-docker = []

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # rpmoci
-*rpmoci is a nascent container build tool from Azure for Operators. It's currently used in a small number of internal container images builds.*
+*rpmoci is a container build tool from Azure for Operators.*
 
 rpmoci builds OCI container images from RPM packages, using [DNF](https://github.com/rpm-software-management/dnf). It's essentially a containerization wrapper around `dnf install --installroot=/some/rootfs PACKAGE [PACAKGE ...]`.
 

--- a/tests/fixtures/capabilities/rpmoci.toml
+++ b/tests/fixtures/capabilities/rpmoci.toml
@@ -1,0 +1,11 @@
+[contents]
+gpgkeys = [
+  "https://raw.githubusercontent.com/microsoft/CBL-Mariner/2.0/SPECS/mariner-repos/MICROSOFT-RPM-GPG-KEY",
+  "https://packages.microsoft.com/keys/microsoft.asc",
+]
+packages = ["cloud-hypervisor", "libcap"]
+[[contents.repositories]]
+url = "https://packages.microsoft.com/cbl-mariner/2.0/prod/base/x86_64"
+
+[image]
+cmd = ["getcap", "/usr/bin/cloud-hypervisor"]


### PR DESCRIPTION
rpmoci currently drops linux capabilities/extended attributes from files in the rpm. tar-rs doesn't support this natively (I'm looking into changing that), so I'm creating a pax header from the existing extended attributes.
