### PR TITLE
use path defaulting code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 ### Added
 ### Fixed
 
+## 0.2.8 - 2023-08-15
+
+### Fixed
+Set a sensible default for the PATH variable correctly.
 
 ## 0.2.7 - 2023-08-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,7 +810,7 @@ checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "rpmoci"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpmoci"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 description = "Build container images from RPMs"
 # rpmoci uses DNF (via pyo3) which is GPLV2+ licensed,


### PR DESCRIPTION
according to
[runtime-spec/config.md at main · opencontainers/runtime-spec (github.com)](https://github.com/opencontainers/runtime-spec/blob/main/config.md#posix-platform-hooks)
, and
http://pubs.opengroup.org/onlinepubs/9699919799/functions/exec.html
, if PATH isn't set then it's up to the container runtime to decide whether or not to do PATH lookups. docker does, but others don't (e.g running an azure container instance)

rpmoci intended to set the PATH variable to sensible default, but that code is not actually used until this PR.