### PR TITLE
ignore rpmlib deps when updating from lockfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 ### Breaking Changes
 ### Added
 ### Fixed
+
+## 0.2.9 - 2023-08-31
+### Fixed
 - When running an unlocked `build` with a lockfile present check that all dependencies are compatible.
 - Set labels from the CLI correctly, regressed in 0.2.8.
+- Ignore "rpmlib" dependencies when resolving RPMs with `rpmoci update --from-lockfile`
 
 ## 0.2.8 - 2023-08-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,7 +810,7 @@ checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "rpmoci"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpmoci"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 description = "Build container images from RPMs"
 # rpmoci uses DNF (via pyo3) which is GPLV2+ licensed,

--- a/src/lockfile/resolve.rs
+++ b/src/lockfile/resolve.rs
@@ -128,6 +128,9 @@ impl Lockfile {
                     .iter()
                     .flat_map(|pkg| pkg.requires.clone()),
             )
+            // dnf is not aware of rpmlib() requirements that the RPMs may have, so we need to filter them out
+            // similar to tdnf: https://github.com/vmware/tdnf/blob/ed235f71ec6d477c8934b82ea12d983c0a8c60d8/client/resolve.c#L508
+            .filter(|requires| !requires.starts_with("rpmlib("))
             .collect::<Vec<_>>();
 
         let mut lockfile = Self::resolve(


### PR DESCRIPTION
if you `rpmoci update --from-lockfile` and your local RPM has rpmlib requirements then the operation fails. These requirements can't be resolved by dnf, so ignore them (similar to tdnf/libsolve, presumably dnf itself).