### PR TITLE
fix oci-layout version to 1.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - uses: oras-project/setup-oras@v1
+        with:
+          version: 1.1.0
       - name: Run cargo test
         run: cargo test --features test-docker
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 ### Added
 ### Fixed
 
+## 0.2.11 - 2023-10-26
+### Fixed
+- Pin oci-layout versions to 1.0.0 rather than using the OCI spec version in `oci_spec` crate.
+  - rpmoci 0.2.10 produces invalid OCI images that are not compatible with the OCI spec, as they have an oci-layout version of 1.0.1.
+
 ## 0.2.10 - 2023-10-25
 ### Fixed
 - Don't attempt to verify signatures from packages from repositories that have `gpgcheck` disabled.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "rpmoci"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1082,7 +1082,6 @@ dependencies = [
  "pathdiff",
  "pyo3",
  "rpm",
- "semver",
  "serde",
  "serde_json",
  "tar",
@@ -1127,12 +1126,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "semver"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpmoci"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2021"
 description = "Build container images from RPMs"
 # rpmoci uses DNF (via pyo3) which is GPLV2+ licensed,
@@ -21,7 +21,6 @@ openssl = "0.10.55"
 pathdiff = "0.2.1"
 pyo3 = { version = "0.19.1", features = ["auto-initialize"] }
 rpm = { version = "0.12.1", default-features = false }
-semver = "1.0.20"
 serde = { version = "1.0.185", features = ["derive"] }
 serde_json = "1.0.105"
 tar = "0.4.38"

--- a/tests/it.rs
+++ b/tests/it.rs
@@ -132,6 +132,8 @@ fn test_update_from_lockfile() {
     assert!(stderr.contains("Updating dnf 4.8.0-1.cm2 -> "));
 }
 
+// This test requires oras be installed, to check that the produced images are
+// compatible with another OCI tool.
 #[test]
 fn test_simple_build() {
     let root = setup_test("simple_build");
@@ -145,6 +147,17 @@ fn test_simple_build() {
         .output()
         .unwrap();
 
+    let oras_status = Command::new("sudo")
+        .arg("oras")
+        .arg("copy")
+        .arg("--from-oci-layout")
+        .arg("--to-oci-layout")
+        .arg("foo:bar")
+        .arg("baz:bar")
+        .current_dir(&root)
+        .status()
+        .unwrap();
+
     // Cleanup using sudo
     let _ = Command::new("sudo")
         .arg("rm")
@@ -156,6 +169,7 @@ fn test_simple_build() {
     let stderr = std::str::from_utf8(&output.stderr).unwrap();
     eprintln!("stderr: {}", stderr);
     assert!(output.status.success());
+    assert!(oras_status.success());
 }
 
 #[test]


### PR DESCRIPTION
https://github.com/microsoft/rpmoci/pull/66 shouldn't have used the version from oci_spec::image, as that isn't the latest oci-layout version (1.0.0)