### PR TITLE
download correct arch packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1236,9 +1236,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
 
 [[package]]
 name = "libredox"
@@ -1873,6 +1873,7 @@ dependencies = [
  "filetime",
  "flate2",
  "glob",
+ "libc",
  "log",
  "ocidir",
  "pathdiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ xattr = "1.0.1"
 ocidir = "0.3.1"
 
 [dev-dependencies]
+libc = "0.2.164"
 test-temp-dir = "0.3.0"
 testcontainers = { version = "0.23.1", features = ["blocking"] }
 testcontainers-modules = { version = "0.11.2", features = [

--- a/src/lockfile/download.py
+++ b/src/lockfile/download.py
@@ -1,4 +1,5 @@
 """RPM downloader module."""
+
 # Copyright (C) Microsoft Corporation.
 #
 # This program is free software: you can redistribute it and/or modify
@@ -37,6 +38,10 @@ def download(base, packages, directory):
 def get_package(base, name, evr, checksum):
     """Find packages matching given spec."""
     pkgs = base.sack.query().filter(name=name, evr=evr).run()
+    # Filter by checksum manually as hawkey does not support it
+    # This also ensures that we get the package for the correct arch
+    # in case $basearch is used in the URL.
+    pkgs = [p for p in pkgs if p.chksum and p.chksum[1].hex() == checksum]
 
     if not pkgs:
         msg = (

--- a/tests/fixtures/basearch/rpmoci.toml
+++ b/tests/fixtures/basearch/rpmoci.toml
@@ -1,0 +1,7 @@
+[contents]
+packages = ["basesystem"]
+
+[[contents.repositories]]
+url = "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/os"
+id = "ubi"
+options = { gpgcheck = "false" }


### PR DESCRIPTION
for repos that use $basearch, we may download the package of the wrong architecture. fix by selecting the package with correct checksum, rather than the first with the correct name/evr

Fixes #174 