### PR TITLE
fix: hint to run rpmoci update when build download fails

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -120,10 +120,10 @@ impl Repository {
         }
 
         // If the repository is a definition, and has an id, return that
-        if let Repository::Definition(repo) = &self {
-            if let Some(repoid) = &repo.id {
-                return repoid.to_string();
-            }
+        if let Repository::Definition(repo) = &self
+            && let Some(repoid) = &repo.id
+        {
+            return repoid.to_string();
         }
 
         // The repository didn't have an id, so generate one from the url

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,13 +161,18 @@ pub fn main(command: Command) -> anyhow::Result<()> {
                 lockfile.write_to_file(lockfile_path)?;
             }
 
-            lockfile.build(
-                &cfg,
-                &image,
-                &tag,
-                vendor_dir.as_deref(),
-                label.into_iter().collect(),
-            )?;
+            lockfile
+                .build(
+                    &cfg,
+                    &image,
+                    &tag,
+                    vendor_dir.as_deref(),
+                    label.into_iter().collect(),
+                )
+                .context(
+                    "If packages in the lock file are no longer available in the configured \
+                     repositories, run `rpmoci update` to regenerate it",
+                )?;
             let elapsed_time = now.elapsed();
             write::ok(
                 "Success",


### PR DESCRIPTION
When pinned packages are removed from a rolling repo (e.g. UBI9 only retains the latest package version), rpmoci build fails at download time with "Package could no longer be found in repositories". The error was correct but gave no guidance on how to resolve it.

Add context to the lockfile.build() call so failures include a suggestion to run `rpmoci update` to regenerate the lock file.