### PR TITLE
feat: re-lock on download failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,13 +46,13 @@ jobs:
   test-fedora:
     runs-on: ubuntu-24.04
     container:
-      image: fedora:40
+      image: fedora:44
       options: --privileged
     steps:
       - name: Install dependencies
         run: |
           dnf install -y openssl-devel python3-devel sqlite-devel dnf-plugins-core util-linux rust cargo skopeo
-          dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+          dnf config-manager addrepo --from-repofile=https://download.docker.com/linux/fedora/docker-ce.repo
           dnf install -y docker-ce-cli
       - uses: actions/checkout@v4
       - name: Run tests

--- a/src/config.rs
+++ b/src/config.rs
@@ -120,10 +120,10 @@ impl Repository {
         }
 
         // If the repository is a definition, and has an id, return that
-        if let Repository::Definition(repo) = &self {
-            if let Some(repoid) = &repo.id {
-                return repoid.to_string();
-            }
+        if let Repository::Definition(repo) = &self
+            && let Some(repoid) = &repo.id
+        {
+            return repoid.to_string();
         }
 
         // The repository didn't have an id, so generate one from the url

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,13 +161,18 @@ pub fn main(command: Command) -> anyhow::Result<()> {
                 lockfile.write_to_file(lockfile_path)?;
             }
 
-            lockfile.build(
-                &cfg,
-                &image,
-                &tag,
-                vendor_dir.as_deref(),
-                label.into_iter().collect(),
-            )?;
+            lockfile
+                .build(
+                    &cfg,
+                    &image,
+                    &tag,
+                    vendor_dir.as_deref(),
+                    label.into_iter().collect(),
+                )
+                .context(
+                    "If packages in the lock file are no longer available in the configured \
+                     repositories, run `rpmoci update` to regenerate it",
+                )?;
             let elapsed_time = now.elapsed();
             write::ok(
                 "Success",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,21 +158,45 @@ pub fn main(command: Command) -> anyhow::Result<()> {
             };
 
             if changed {
-                lockfile.write_to_file(lockfile_path)?;
+                lockfile.write_to_file(&lockfile_path)?;
             }
 
-            lockfile
+            match lockfile
                 .build(
                     &cfg,
                     &image,
                     &tag,
                     vendor_dir.as_deref(),
-                    label.into_iter().collect(),
+                    label.clone().into_iter().collect(),
                 )
                 .context(
                     "If packages in the lock file are no longer available in the configured \
                      repositories, run `rpmoci update` to regenerate it",
-                )?;
+                ) {
+                Ok(()) => (),
+                Err(e) => {
+                    // running unlocked with a compatible lockfile: packages may have been
+                    // removed from the rolling repo, so attempt an auto-update and retry.
+                    if lockfile.is_compatible_including_local_rpms(&cfg)? && !locked {
+                        log::debug!(
+                            "Build failed with a compatible lockfile, attempting auto-update and rebuild."
+                        );
+                        let lockfile = Lockfile::resolve_from_config(&cfg)?;
+                        lockfile.write_to_file(&lockfile_path)?;
+                        lockfile.build(
+                            &cfg,
+                            &image,
+                            &tag,
+                            vendor_dir.as_deref(),
+                            label.into_iter().collect(),
+                        )?;
+                    } else {
+                        // locked or lockfile no longer matches config – bail with the
+                        // hint already included in the error context.
+                        bail!("Failed to build image: {e}.");
+                    }
+                }
+            };
             let elapsed_time = now.elapsed();
             write::ok(
                 "Success",

--- a/tests/fixtures/ubi9/foo/oci-layout
+++ b/tests/fixtures/ubi9/foo/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/tests/fixtures/ubi9/rpmoci.toml
+++ b/tests/fixtures/ubi9/rpmoci.toml
@@ -1,0 +1,10 @@
+[contents]
+packages = ["glibc"]
+
+[[contents.repositories]]
+url = "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/os"
+id = "ubi9-test"
+options = { gpgcheck = "false" }
+
+[image]
+cmd = ["/bin/bash"]

--- a/tests/it.rs
+++ b/tests/it.rs
@@ -385,6 +385,12 @@ fn test_exclude() {
     build_and_run("exclude", false);
 }
 
+#[cfg(feature = "test-docker")]
+#[test]
+fn test_auto_update_missing_package() {
+    build_and_run("ubi9", true);
+}
+
 fn build_and_run(image: &str, should_succeed: bool) -> std::process::Output {
     let (_tmp_dir, root) = setup_test(image);
     let status = rpmoci()


### PR DESCRIPTION
When running rpmoci (specifically on ubi9 rpm repos) there is a class of error where the lockfile is valid but the rpms referenced in the lockfile are no longer present in the rpm repos specified. 
This PR attempts to address the above issue by regenerating the lockfile when running an unlocked build with a valid lockfile. 

The downside of this is that lockfile regeneration will occur when an unlocked valid lockfile build fails for any reason. 